### PR TITLE
json 1.8.1 cannot built with ruby 2.3.x, so upgraded to 1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       activesupport (>= 4.1.0)
     hike (1.2.3)
     i18n (0.7.0)
-    json (1.8.1)
+    json (1.8.2)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
     mail (2.6.3)


### PR DESCRIPTION
Ruby 2.3.0

While I was installing gems, an error came out:

```
make "DESTDIR="
compiling generator.c
In file included from generator.c:1:0:
../fbuffer/fbuffer.h: In function ‘fbuffer_to_s’:
../fbuffer/fbuffer.h:175:47: error: macro "rb_str_new" requires 2 arguments, but only 1 given
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                                               ^
../fbuffer/fbuffer.h:175:20: warning: initialization makes integer from pointer without a cast [-Wint-conversion]
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                    ^
Makefile:238: recipe for target 'generator.o' failed
make: *** [generator.o] Error 1

make failed, exit code 2
```

This lead me to this issue: https://github.com/flori/json/issues/229.

And I upgraded it to 1.8.2, so after installing, `rails s` can work normally.